### PR TITLE
Demo of dogstatsd server overflown with packets

### DIFF
--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -535,7 +535,9 @@ func (s *Server) parsePackets(batcher *batcher, parser *parser, packets []*packe
 
 				debugEnabled := atomic.LoadUint64(&s.Debug.Enabled) == 1
 
-				samples, err = s.parseMetricMessage(samples, parser, message, packet.Origin, debugEnabled)
+        //use hardcoded origin because if dogstatd runs locally packet.Origin is empty
+        origin := "mac_book_pro"
+				samples, err = s.parseMetricMessage(samples, parser, message, origin, debugEnabled)
 				if err != nil {
 					s.errLog("Dogstatsd: error parsing metric message '%q': %s", message, err)
 					continue


### PR DESCRIPTION
This PR aims to demonstrate a specific situation in which dogstatsd server fails to process metrics. `ECSCollecter` was changed to model the situation were it was successfully detected and registered but fails to load tags from ECS metadata endpoint. 
```
ESCCollector.Detect - always successflul
ESCCollector.Fetch - fail with delay
```
If the endpoint is unresponsive, request fails with default timeout 0.5second.  When request to collector fails we retry it next time(see [here](https://github.com/boh-dan/datadog-agent/blob/master/pkg/tagger/local/tagger.go#L260)). If request fails all the time it means that we spend 0.5s for every packet. Event small amount of packets creates significant delay(for example, 1000packets 8 minutes.) It leads to rapid growth of the packet queue and in the end datadog agent dies. Also it prevents other metrics from being sent.

In order to run locally please enable flag `dogstatsd_origin_detection` in the config.